### PR TITLE
Occasional timeouts on readADC()

### DIFF
--- a/ADS1X15.cpp
+++ b/ADS1X15.cpp
@@ -454,14 +454,14 @@ int16_t ADS1X15::_readADC(uint16_t readmode)
     uint32_t start = millis();
     //  timeout == { 129, 65, 33, 17, 9, 5, 3, 2 }
     //  a few ms more than max conversion time.
-    uint8_t timeOut = (128 >> (_datarate >> 5)) + 1;
+    uint8_t timeOut = (128 >> (_datarate >> 5)) + 10;
     while (isBusy())
     {
-      yield();   //  wait for conversion; yield for ESP.
       if ( (millis() - start) > timeOut)
       {
         return ADS1X15_ERROR_TIMEOUT;
       }
+      yield();   //  wait for conversion; yield for ESP.
     }
   }
   else


### PR DESCRIPTION
Occasional Timeouts were detected when running on a ESP8266.
       - See https://www.circuitsonline.net/forum/view/167087
    
Problem is due to timeout settings in readADC(). These leave very little margin.
   - The yield() may trigger a task switch on an ESP and processing may be  suspended for several milliseconds. - Fixed by allowing a 10 millisecond margin on timeouts
    
Also fixed by postponing the yield() until after the timeout check
      -  This way the system performs at least one other round before going into timeout. -  This is still not 100% fail-safe as the OS may allow for interrupts and task-switches outside of the yield function